### PR TITLE
Clarification du statut de Membre Alumni et modification des contraintes

### DIFF
--- a/Statuts.md
+++ b/Statuts.md
@@ -89,7 +89,7 @@ Elle est décernée aux personnes physiques qui ont rendu des services éminents
 
 Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
 
-Les Membres Émérites sont Membres à Vie de l’association et ne prennent pleinement leur statut qu'à partir du moment où ils ne sont plus Membre Annuel.
+Les Membres Émérites sont Membres à Vie de l’association. Le statut de Membre Émérite est cummulable avec le statut de membre annuel et de Membre d'Honneur.
 
 Le nombre d’attribution au statut de Membres Émérites est limité à 10 étudiants par année scolaire (de septembre à mai).
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -74,7 +74,7 @@ La qualité de Membre Émérite est décernée en Assemblée Générale, sans vo
 
 Elle est décernée aux personnes physiques qui ont rendu des services éminents à l’association.
 
-Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
+Cette qualité ne peut être attribué qu'à un Membre Annuel faisant partie de l'association depuis plus d'un an révolu.
 
 Les Membres Émérites sont Membres à Vie de l’association. Le statut de Membre Émérite est cummulable avec le statut de membre annuel et de Membre d'Honneur.
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -85,9 +85,9 @@ Les Membres d’Honneur sont des membres à vie de l’Association.
 
 La qualité de Membre-Alumni est décernée en Assemblée Générale, sans vote et sur proposition du Bureau.
 
-Elle est décernée aux personnes phyisques qui ont rendu des services éminents à l’association.
+Elle est décernée aux personnes physiques qui ont rendu des services éminents à l’association.
 
-Cette qualité ne peut être attribué qu'à un membre annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
+Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
 
 Les Membres-Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -85,7 +85,6 @@ Cette qualité ne peut être attribué qu'à un ou une membre annuel ayant valid
 
 Les Membres Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
 
-De plus, l’étudiant doit faire partie de l’association pour une durée minimum de 2 ans scolaires (de septembre à mai) pour devenir Membre Alumni.
 Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à août).
 
 ### Section 2.5 : Admissions

--- a/Statuts.md
+++ b/Statuts.md
@@ -73,12 +73,15 @@ Les Membres d’Honneur sont des membres à vie de l’association.
 
 ### Section 2.3 : Membres Alumnis
 
-La qualité de Membre Alumni est décernée en Assemblée Générale sans vote sur proposition du bureau, aux personnes physiques ou morales qui ont rendu des services éminents à l’association.
-Cette qualité ne peut être attribué qu'à un ou une membre annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
+La qualité de Membre-Alumni est décernée en Assemblée Générale, sans vote et sur proposition du Bureau.
 
-Les Membres Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
+Elle est décernée aux personnes phyisques qui ont rendu des services éminents à l’association.
 
-Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à août).
+Cette qualité ne peut être attribué qu'à un membre annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
+
+Les Membres-Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
+
+Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à mai).
 
 ### Section 2.4 : Membres annuels
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -42,9 +42,9 @@ Pour cela, les décisions et propositions allant être soumises à une Assemblé
 Une fois proposée en AG, une proposition n’est plus soumise au veto des membres du CC.
 
 Le Comité de Contrôle possède toujours 2 ou 3 membres. Les membres du CC sont tenus dans les registres faisant foi des membres du CC.
-Si le CC se trouve à 1 membre, il doit recruter 1 ou 2 nouveaux membres parmi les Membres d'Honneur et Membres Alumnis.
+Si le CC se trouve à 1 membre, il doit recruter 1 ou 2 nouveaux membres parmi les Membres d'Honneur et Membres Émérites.
 
-Le Comité de Contrôle peut décider à l'unanimité de se dissoudre. Auquel cas il revient au Comité de Direction de recruter 2 ou 3 membres parmi les Membres d'Honneur et Membres Alumnis.
+Le Comité de Contrôle peut décider à l'unanimité de se dissoudre. Auquel cas il revient au Comité de Direction de recruter 2 ou 3 membres parmi les Membres d'Honneur et Membres Émérites.
 
 ### Section 1.7 : Ressources
 
@@ -63,7 +63,7 @@ L’Association comprend les qualités de membres suivantes:
 
 - Membres fondateurs ;
 - Membres d’Honneur ;
-- Membres Alumnis ;
+- Membres Émérites ;
 - Membres annuels ;
 - Persona Non Grata.
 
@@ -72,7 +72,7 @@ L’Association comprend les qualités de membres suivantes:
 Les membres fondateurs sont les personnes ayant constitué l’Association en 2015, à savoir : Angéline BESLAND (Présidente), Gaël NAIME (Trésorier) et Dany NARCISSE (Secrétaire Général).
 
 Leurs noms figurent ci-dessus sur ce statut et doivent figurer, dans l’éventualité que cela se produise, sur tous les prochains statuts de l’Association sous le même format.
-Les droits des membres fondateurs incluent tous les droits des Membres d’Honneur et d’Alumni au minima.
+Les droits des membres fondateurs incluent tous les droits des Membres d’Honneur et des Membres Émérites au minima.
 Les membres fondateurs sont des membres à vie de l’Association.
 
 ### Section 2.2 : Membres d'honneur
@@ -81,17 +81,17 @@ La qualité de Membre d’Honneur est décernée par l’Assemblée Générale. 
 Le nombre d'attributions au statut de Membre d’Honneur de l’Association est limité à 3 étudiants par année scolaire.
 Les Membres d’Honneur sont des membres à vie de l’Association.
 
-### Section 2.3 : Membres Alumnis
+### Section 2.3 : Membres Émérites
 
-La qualité de Membre-Alumni est décernée en Assemblée Générale, sans vote et sur proposition du Bureau.
+La qualité de Membre Émérite est décernée en Assemblée Générale, sans vote et sur proposition du Bureau.
 
 Elle est décernée aux personnes physiques qui ont rendu des services éminents à l’association.
 
 Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
 
-Les Membres-Alumni sont Membres à Vie de l’association et ne prennent pleinement leur statut qu'à partir du moment où ils ne sont plus Membre Annuel.
+Les Membres Émérites sont Membres à Vie de l’association et ne prennent pleinement leur statut qu'à partir du moment où ils ne sont plus Membre Annuel.
 
-Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à mai).
+Le nombre d’attribution au statut de Membres Émérites est limité à 10 étudiants par année scolaire (de septembre à mai).
 
 ### Section 2.4 : Membres Annuels
 
@@ -229,7 +229,7 @@ Les procès-verbaux des délibérations de l'Assemblée Générale sont tenus pa
 Une Assemblée Générale est compétente de :
 
 - l'élection entière ou partielle du Bureau,
-- l'attribution du statut de Membre d'Honneur ou Membre Alumni.
+- l'attribution du statut de Membre d'Honneur ou Membre Émérites.
 
 ### Section 4.1 : Assemblée Générale Ordinaire
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -89,7 +89,7 @@ Elle est décernée aux personnes physiques qui ont rendu des services éminents
 
 Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
 
-Les Membres-Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
+Les Membres-Alumni sont Membres à Vie de l’association et ne prennent pleinement leur statut qu'à partir du moment où ils ne sont plus Membre Annuel.
 
 Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à mai).
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -78,11 +78,15 @@ La qualité de membre d’honneur est décernée par l’assemblée générale. 
 Le nombre d'attributions au statut de membre d’honneur de l’association est limité à 3 étudiants par année scolaire.
 Les membres d’honneur sont des membres à vie de l’association.
 
-### Section 2.4 : Membres alumnis
+### Section 2.4 : Membres Alumnis
 
-La qualité de membres alumni est décernée par l’assemblée générale sur proposition du bureau, aux personnes physiques ou morales qui ont rendu des services éminents à l’association. Les membres deviennent pleinement membres alumni à la fin de leur études, c’est à dire une fois la dernière année universitaire d’un cursus de l’ESILV, l’EMLV et l’IIM est terminé ou s’il part à l’étranger à partir de la 5e année. Un étudiant ayant quitté l’ESILV, l’EMLV ou l’IIM, et ayant validé au moins une année scolaire dans l’une de ces 3 écoles peut devenir membre alumni. Mais un membre étudiant d’une des 3 écoles (ESILV, EMLV, IIM) n’ayant jamais validé d’année scolaire ne peut pas être membre alumni.
-De plus, l’étudiant doit faire partie de l’association pour une durée minimum de 2 ans scolaires (de septembre à mai) pour devenir alumni. Le nombre d’attribution au statut de membre alumni est limité à 10 étudiants par année scolaire.
-Les membres alumni sont donc des membres à vie de l’association.
+La qualité de Membre Alumni est décernée en Assemblée Générale sans vote sur proposition du bureau, aux personnes physiques ou morales qui ont rendu des services éminents à l’association.
+Cette qualité ne peut être attribué qu'à un ou une membre annuel ayant validé au moins une année scolaire dans l'une des trois écoles du Pôle Léonard de Vinci (EMLV, ESILV et IIM).
+
+Les Membres Alumni sont Membres à Vie de l’association et sont exemptés de la cotisation annuelle à partir du moment où ils ne sont plus étudiant dans une des écoles du Pôle Léonard de Vinci.
+
+De plus, l’étudiant doit faire partie de l’association pour une durée minimum de 2 ans scolaires (de septembre à mai) pour devenir Membre Alumni.
+Le nombre d’attribution au statut de Membre Alumni est limité à 10 étudiants par année scolaire (de septembre à août).
 
 ### Section 2.5 : Admissions
 

--- a/Statuts.md
+++ b/Statuts.md
@@ -78,8 +78,6 @@ Cette qualité ne peut être attribué qu'à un Membre Annuel ayant validé au m
 
 Les Membres Émérites sont Membres à Vie de l’association. Le statut de Membre Émérite est cummulable avec le statut de membre annuel et de Membre d'Honneur.
 
-Le nombre d’attribution au statut de Membres Émérites est limité à 10 étudiants par année scolaire (de septembre à mai).
-
 ### Section 2.4 : Membres Annuels
 
 #### Sous-Section 2.4.1 : Définition


### PR DESCRIPTION
- Clarification des conditions à l'attribution du statut
- Suppression du délai à l'application du statut
> Le statut est donnée immédiatement et non plus à la fin des études du membre. Ce changement est fait dans un objectif de clarté, parce que la date d'application du statut en vrai on s'en fiche, ce qui est important c'est la partie membre à vie.
- Suppression de la contrainte des 2 années dans l'asso
> Déjà dans un soucis de cohérence avec le statut de Membre d'Honneur et ensuite parce que la règle de devoir valider une année scolaire au Pôle enforce déjà cette règle. Donc autant être un chouille être plus permissif, c'est un bon moyen de remercier des 1ere années très impliqués ou qui ont fait des trucs particulièrement cools.
- Ajout de la mention d'exemption de la cotisation après les études