### PR TITLE
Suppression du vote des MH avant l'AG

### DIFF
--- a/Statuts.md
+++ b/Statuts.md
@@ -90,7 +90,7 @@ L'attribution du statut de Membre d'Honneur se fait en plusieurs temps :
 - Les propositions ainsi validées sont ensuite votées en Assemblée Générale où la majorité relative décide de l'attribution du statut.
 - Les membres se voyant décerné le statut de Membre d'Honneur disposent d'un délai d'une semaine pour l'accepter ou le refuser individuellement. Passé ce délai, le statut de Membre d'Honneur sera considéré comme accepté. En cas de refus, la remise du statut pourra être faite à un prochain vote.
 
-Le nombre d'attributions du statut de Membre d’Honneur de l’association est limité à 4 étudiants par année scolaire (de septembre à août).
+Le nombre d'attributions du statut de Membre d’Honneur de l’association est limité à 4 étudiants par année scolaire. L'année scolaire est définie dans l'[Article 2.4.1](#sous-section-241--définition).
 
 Les Membres d’Honneur sont Membres à Vie de l’association.
 La qualité de Membre d'Honneur n'est pas cumulable avec celle de membre annuel, de ce fait un membre se voyant décerné la qualité de Membre d'Honneur perd celle de membre annuel.

--- a/Statuts.md
+++ b/Statuts.md
@@ -85,9 +85,7 @@ Les conditions s'appliquant à l'attribution du statut de Membre Émérite s'app
 
 L'attribution du statut de Membre d'Honneur se fait en plusieurs temps :
 
-- le Bureau propose des membres annuels auxquels attribuer le statut et le soumet aux Membres d'Honneur.
-- Les Membres d'Honneur votent à la majorité relative la proposition de chaque nouveau Membre d'Honneur, avec un minimum de 3 votants.
-- Les propositions ainsi validées sont ensuite votées en Assemblée Générale où la majorité relative décide de l'attribution du statut.
+- le Bureau propose des membres annuels auxquels attribuer le statut et les soumets en Assemblée Générale où la majorité relative décide de l'attribution du statut.
 - Les membres se voyant décerné le statut de Membre d'Honneur disposent d'un délai d'une semaine pour l'accepter ou le refuser individuellement. Passé ce délai, le statut de Membre d'Honneur sera considéré comme accepté. En cas de refus, la remise du statut pourra être faite à un prochain vote.
 
 Le nombre d'attributions du statut de Membre d’Honneur de l’association est limité à 4 étudiants par année scolaire. L'année scolaire est définie dans l'[Article 2.4.1](#sous-section-241--définition).


### PR DESCRIPTION
Les membres annuels présents à l'AG connaissent bien mieux que les anciens MH partis depuis plusieurs années les membres proposés pour le statut. La proposition auprès des anciens MH est donc infondées et ne permet pas de juger de la réelle validité de l'attribution du statut.